### PR TITLE
Stones weight unit support

### DIFF
--- a/LineDietXF/LineDietXF/App.xaml
+++ b/LineDietXF/LineDietXF/App.xaml
@@ -28,6 +28,7 @@
       <Color x:Key="ButtonFillColor">#66ffffff</Color>
       <Color x:Key="ButtonTextColor">#ffffff</Color>
       <Color x:Key="EntryPlaceholderColor">#66ffffff</Color>
+      <Color x:Key="LoadingOverlayColor">#44000000</Color>
 
       <!-- label styles -->
       <OnPlatform x:Key="ThinFontFamilyStyle"

--- a/LineDietXF/LineDietXF/App.xaml
+++ b/LineDietXF/LineDietXF/App.xaml
@@ -12,6 +12,7 @@
       <cvt:DateValueConverter x:Key="DateCvt" />
       <cvt:CheckmarkVisibilityConverter x:Key="CheckmarkVisCvt" />      
       <cvt:InverseBooleanConverter x:Key="InverseBoolConverter" />
+      <cvt:WeightListingFontSizeConverter x:Key="WeightListingFontSizeCvt" />
 
       <!-- dynamic colors -->
       <Color x:Key="PrimaryResultColor">#808080</Color>

--- a/LineDietXF/LineDietXF/App.xaml
+++ b/LineDietXF/LineDietXF/App.xaml
@@ -80,21 +80,28 @@
         <Setter Property="TextColor" Value="{DynamicResource PrimaryResultColor}"/>
         <Setter Property="FontSize" Value="28"/>
       </Style>
-
-      <!-- button styles -->
-      <!-- Android buttons are inset a bit and don't line up with entry fields, so setting global negative left/right margins to fix this globally -->
-      <OnPlatform x:Key="ButtonMargin"  
-                  x:TypeArguments="Thickness"
-                  iOS="0,0,0,6"
-                  Android="-4,0,-4,6"
-                  WinPhone="0,0,0,0" />
-      
+     
+      <!-- button styles -->      
       <Style x:Key="BoxButtonStyle" TargetType="Button">
         <Setter Property="BorderRadius" Value="0" />
         <Setter Property="BackgroundColor" Value="{StaticResource ButtonFillColor}" />
         <Setter Property="FontFamily" Value="{DynamicResource NormalFontFamilyStyle}" />
         <Setter Property="TextColor" Value="{StaticResource ButtonTextColor}" />
-        <Setter Property="Margin" Value="{DynamicResource ButtonMargin}" />
+        <Setter Property="Margin" Value="0,0,0,6" />
+      </Style>
+
+      <!-- Android buttons are inset a bit and don't line up with entry fields, so the ButtonWrappingPanel helps them align
+           NOTE:: Initially this was done on the BoxButtonStyle, however it was noticed that if there were multiple buttons that
+           only the first would align. This issue appeared after adding the weight field wrapping grids for showing/hiding different
+           weight fields for kg/pounds VS stones. Instead applying the margin on a wrapping StackLayout for the buttons works fine. -->
+      <OnPlatform x:Key="ButtonWrappingPanelMargin"
+                  x:TypeArguments="Thickness"
+                  iOS="0,20,0,8"
+                  Android="-4,20,-4,8"
+                  WinPhone="0,20,0,8" />
+
+      <Style x:Key="ButtonWrappingPanel" TargetType="StackLayout">
+        <Setter Property="Margin" Value="{StaticResource ButtonWrappingPanelMargin}" />
       </Style>
 
       <!-- entry styles -->

--- a/LineDietXF/LineDietXF/Constants.App.cs
+++ b/LineDietXF/LineDietXF/Constants.App.cs
@@ -16,6 +16,7 @@ namespace LineDietXF.Constants
 
         public static int HISTORY_WeightEntryMaxCount = 31;
         public const int SetGoalPage_DefaultGoalDateOffsetInMonths = 3; // default new goal end date to X months from now
+        public const int PoundsInAStone = 14;
 
         // Settings
         public const string Settings_HasDismissedStartupView = "HasDismissedStartupView";

--- a/LineDietXF/LineDietXF/Constants.Strings.cs
+++ b/LineDietXF/LineDietXF/Constants.Strings.cs
@@ -20,7 +20,7 @@ namespace LineDietXF.Constants
         public const string Common_SaveError = "Error while saving";
         public const string Common_FatalError = "Fatal Error";
         public const string Common_SettingWeightUnits_Title = "Weight Units Setting";
-        public const string Common_SettingWeightUnits_Message = "Line Diet is currently using {0} for weight measurements. You can change this by going to the menu tab, and selecting Settings.";
+        public const string Common_SettingWeightUnits_Message = "Line Diet is currently set to use {0} for weight measurements. You can change this by going to the menu tab, and selecting Settings.";
 
         // Getting Started
         public static string GettingStarted_Page1Title = $"Welcome to {Environment.NewLine} Line Diet!";

--- a/LineDietXF/LineDietXF/Constants.Strings.cs
+++ b/LineDietXF/LineDietXF/Constants.Strings.cs
@@ -13,7 +13,8 @@ namespace LineDietXF.Constants
         public const string Common_WeightUnit_Kilograms = "kilograms";
         public const string Common_WeightUnit_Stones = "stones";
         public const string Common_WeightFormat = "{0:0.0}";
-        public const string Common_Stones_WeightFormat = "{0:0}st {1:0.0}lb";
+        public const string Common_Stones_WeightFormat = "{0:0}st {1:0.0}lbs";
+        public const string Common_Stones_ShortWeightFormat = "{0:0.0}st";
         public const string Common_UpdateExistingWeight_Title = "Update existing entry?";
         public const string Common_UpdateExistingWeight_Message = "The existing weight of {0:0.0} on {1:MM/dd/yyyy} will be updated with the weight of {2:0.0}.";
         public const string Common_SaveError = "Error while saving";

--- a/LineDietXF/LineDietXF/Constants.Strings.cs
+++ b/LineDietXF/LineDietXF/Constants.Strings.cs
@@ -19,7 +19,7 @@ namespace LineDietXF.Constants
         public const string Common_UpdateExistingWeight_Message = "The existing weight of {0:0.0} on {1:MM/dd/yyyy} will be updated with the weight of {2:0.0}.";
         public const string Common_SaveError = "Error while saving";
         public const string Common_FatalError = "Fatal Error";
-        public const string Common_SettingWeightUnits_Title = "Weight Units Setting";
+        public const string Common_SettingWeightUnits_Title = "Weight Unit Setting";
         public const string Common_SettingWeightUnits_Message = "Line Diet is currently set to use {0} for weight measurements. You can change this by going to the menu tab, and selecting Settings.";
 
         // Getting Started
@@ -101,6 +101,7 @@ namespace LineDietXF.Constants
         public const string WeightEntryPage_Save_RemoveExistingWeightFailed_Message = "An error occurred removing an existing weight entry for the selected date.";
         public const string WeightEntryPage_Save_AddingWeightFailed_Message = "An error occurred when adding the new weight entry.";
         public const string WeightEntryPage_Save_Exception_Message = "An exception occurred while saving your weight entry.";
+        public const string WeightEntrylPage_WeightLabel = "Weight (in {0})";
 
         // Set Goal Page
         public const string SetGoalPage_InvalidWeight_Title = "Invalid weight";
@@ -111,6 +112,8 @@ namespace LineDietXF.Constants
         public const string SetGoalPage_Save_AddingWeightFailed_Message = "An error occurred adding a new weight entry for the goal start date.";
         public const string SetGoalPage_Save_AddingGoalFailed_Message = "An error occurred creating the new weight loss goal.";
         public const string SetGoalPage_Save_Exception_Message = "An exception occurred while saving your weight loss goal.";
+        public const string SetGoalPage_StartWeightLabel = "Start Weight (in {0})";
+        public const string SetGoalPage_GoalWeightLabel = "Goal Weight (in {0})";
 
         // Sharing
         public const string ShareTitle = "Check out Line Diet!";

--- a/LineDietXF/LineDietXF/Constants.Strings.cs
+++ b/LineDietXF/LineDietXF/Constants.Strings.cs
@@ -13,8 +13,8 @@ namespace LineDietXF.Constants
         public const string Common_WeightUnit_Kilograms = "kilograms";
         public const string Common_WeightUnit_Stones = "stones";
         public const string Common_WeightFormat = "{0:0.0}";
-        public const string Common_Stones_WeightFormat = "{0:0}st {1:0.0}lbs";
-        public const string Common_Stones_ShortWeightFormat = "{0:0.0}st";
+        public const string Common_Stones_WeightFormat = "{0:0}st {1:0.#}lbs";
+        public const string Common_Stones_ShortWeightFormat = "{0:0.#}st";
         public const string Common_UpdateExistingWeight_Title = "Update existing entry?";
         public const string Common_UpdateExistingWeight_Message = "The existing weight of {0:0.0} on {1:MM/dd/yyyy} will be updated with the weight of {2:0.0}.";
         public const string Common_SaveError = "Error while saving";

--- a/LineDietXF/LineDietXF/Constants.Strings.cs
+++ b/LineDietXF/LineDietXF/Constants.Strings.cs
@@ -80,7 +80,7 @@ namespace LineDietXF.Constants
         public const string Settings_ChangeWeightUnitsActionSheet = "Select the weight units to use";
         public const string Settings_ChangeWeightUnits_GetWeightsError_Title = "Unable to get weights";
         public const string Settings_ChangeWeightUnits_GetWeightsError_Message = "An error occurred trying to retrieve your weights, cannot continue.";        
-        public const string Settings_ChangeWeightUnits_ConvertWarning = "Convert existing weights to new units (ex: 100.0 pounds becomes 45.36 kilos), or change the units and keep the same weight values (ex: 100.0 pounds becomes 100.0 kilos)?";
+        public const string Settings_ChangeWeightUnits_ConvertWarning = "Convert weights to new units (ex: 100.0 pounds to 45.36 kilos)?";
         public const string Settings_ChangeWeightUnits_ConvertWarning_ConvertWeightValues = "Convert weight values";
         public const string Settings_ChangeWeightUnits_ConvertWarning_ChangeUnits = "Just change units";
         public const string Settings_ChangeWeightUnits_ConvertWeightValues_FatalError = "A fatal error occurred converting weight values, please contact support at smartypantscoding@gmail.com. Details: ";

--- a/LineDietXF/LineDietXF/Constants.Strings.cs
+++ b/LineDietXF/LineDietXF/Constants.Strings.cs
@@ -97,14 +97,14 @@ namespace LineDietXF.Constants
         public const string WeightEntryPage_Title_Add = "Enter Weight";
         public const string WeightEntryPage_Title_Update = "Update Weight";
         public const string WeightEntryPage_InvalidWeight_Title = "Invalid weight";
-        public const string WeightEntryPage_InvalidWeight_Message = "Could not convert entered weight to a valid numerical weight.";
+        public const string WeightEntryPage_InvalidWeight_Message = "Could not convert entered weight to a valid weight.";
         public const string WeightEntryPage_Save_RemoveExistingWeightFailed_Message = "An error occurred removing an existing weight entry for the selected date.";
         public const string WeightEntryPage_Save_AddingWeightFailed_Message = "An error occurred when adding the new weight entry.";
         public const string WeightEntryPage_Save_Exception_Message = "An exception occurred while saving your weight entry.";
 
         // Set Goal Page
         public const string SetGoalPage_InvalidWeight_Title = "Invalid weight";
-        public const string SetGoalPage_InvalidWeight_Message = "Could not convert entered goal weight to a valid numerical weight.";
+        public const string SetGoalPage_InvalidWeight_Message = "Could not convert entered start and/or goal weight into a valid weight.";
         public const string SetGoalPage_GoalWeightGreaterThanStartWeight_Title = "Are you sure?";
         public const string SetGoalpage_GoalWeightGreaterThanStartWeight_Message = "Your goal weight is greater than your start weight. Are you sure your goal is to gain weight?";
         public const string SetGoalPage_Save_RemoveExistingWeightFailed_Message = "An error occurred removing an existing weight entry for the goal start date.";

--- a/LineDietXF/LineDietXF/Constants.Strings.cs
+++ b/LineDietXF/LineDietXF/Constants.Strings.cs
@@ -11,7 +11,9 @@ namespace LineDietXF.Constants
         // Common strings - used multiple places
         public const string Common_WeightUnit_ImperialPounds = "pounds";
         public const string Common_WeightUnit_Kilograms = "kilograms";
+        public const string Common_WeightUnit_Stones = "stones";
         public const string Common_WeightFormat = "{0:0.0}";
+        public const string Common_Stones_WeightFormat = "{0:0}st {1:0.0}lb";
         public const string Common_UpdateExistingWeight_Title = "Update existing entry?";
         public const string Common_UpdateExistingWeight_Message = "The existing weight of {0:0.0} on {1:MM/dd/yyyy} will be updated with the weight of {2:0.0}.";
         public const string Common_SaveError = "Error while saving";
@@ -40,6 +42,7 @@ namespace LineDietXF.Constants
         public const string DailyInfoPage_GoalEnd_Success = "You've reached your goal! You can continue to use Line Diet to track your maintenance of your weight, or set a new goal. Congratulations!";
         public const string DailyInfoPage_GoalEnd_Failure = "It looks like you've fallen short of your goal. Why not set a new goal and try again?";
         public const string DailyInfoPage_ProgressSummary = "You have {0} {1:0.0} {2} since starting your current goal {3} days ago. You have {4} days left to lose {5:0.0} {2}. {6}";
+        public const string DailyInfoPage_Stones_ProgressSummary = "You have {0} {1:0} stone(s) {2:0.0} pounds, since starting your current goal {3} days ago. You have {4} days left to lose {5:0} stone(s), {6:0.0} pounds. {7}";
         public const string DailyInfoPage_Summary_Gained = "gained";
         public const string DailyInfoPage_Summary_Lost = "lost";
         public const string DailyInfoPage_SummaryEnding_OnTrack = "Keep up the good work!";
@@ -72,6 +75,7 @@ namespace LineDietXF.Constants
         public const string Settings_WeightUnits = "Measurement Units: ";
         public const string Settings_ImperialPound = "Imperial Pound (US)";
         public const string Settings_Kilograms = "Kilograms";
+        public const string Settings_StonesAndPounds = "Stones";
         public const string Settings_ChangeWeightUnitsActionSheet = "Select the weight units to use";
         public const string Settings_ChangeWeightUnits_GetWeightsError_Title = "Unable to get weights";
         public const string Settings_ChangeWeightUnits_GetWeightsError_Message = "An error occurred trying to retrieve your weights, cannot continue.";        

--- a/LineDietXF/LineDietXF/Constants.UI.cs
+++ b/LineDietXF/LineDietXF/Constants.UI.cs
@@ -5,6 +5,11 @@ namespace LineDietXF.Constants
 {
     public static class UI
     {
+        public const int DailyInfoFontSize_Normal = 72;
+        public const int DailyInfoFontSize_Stones = 48;
+        public const int ListingFontSize_Normal = 24;
+        public const int ListingFontSize_Stones = 20;
+
         public static Color COLOR_LIGHTGRAY_FILL = Color.FromRgb(128, 128, 128);
         public static Color COLOR_DARKGRAY_FILL = Color.FromRgb(64, 64, 64);
         public static Color COLOR_LIGHTGREEN_FILL = Color.FromRgb(0, 212, 35);

--- a/LineDietXF/LineDietXF/Controls/LoadingIndicator.xaml
+++ b/LineDietXF/LineDietXF/Controls/LoadingIndicator.xaml
@@ -7,7 +7,7 @@
       HorizontalOptions="Fill"
       VerticalOptions="Fill"
       RowSpacing="0"
-      BackgroundColor="{StaticResource SlightDimmingOverlayColor}">
+      BackgroundColor="{StaticResource LoadingOverlayColor}">
     <ActivityIndicator Style="{StaticResource LoadingStyle}" 
                        IsRunning="{Binding IsBusy}"
                        IsVisible="{Binding IsBusy}"/>

--- a/LineDietXF/LineDietXF/Converters/WeightListingFontSizeConverter.cs
+++ b/LineDietXF/LineDietXF/Converters/WeightListingFontSizeConverter.cs
@@ -1,0 +1,28 @@
+﻿using LineDietXF.Enumerations;
+using LineDietXF.Types;
+using System;
+using System.Globalization;
+using Xamarin.Forms;
+
+namespace LineDietXF.Converters
+{
+    public class WeightListingFontSizeConverter : IValueConverter
+    {
+        public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            var weightEntry = value as WeightEntry;
+            if (weightEntry == null)
+                return Constants.UI.ListingFontSize_Normal;
+
+            if (weightEntry.WeightUnit == WeightUnitEnum.StonesAndPounds)
+                return Constants.UI.ListingFontSize_Stones;
+            else
+                return Constants.UI.ListingFontSize_Normal;
+        }
+
+        public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/LineDietXF/LineDietXF/Enumerations/WeightUnitEnum.cs
+++ b/LineDietXF/LineDietXF/Enumerations/WeightUnitEnum.cs
@@ -6,6 +6,7 @@
     public enum WeightUnitEnum
     {
         ImperialPounds,
-        Kilograms
+        Kilograms,
+        StonesAndPounds
     }
 }

--- a/LineDietXF/LineDietXF/Extensions/StonesAndPoundsExtensions.cs
+++ b/LineDietXF/LineDietXF/Extensions/StonesAndPoundsExtensions.cs
@@ -1,0 +1,39 @@
+﻿using LineDietXF.Types;
+using System;
+
+namespace LineDietXF.Extensions
+{
+    public static class StonesAndPoundsExtensions
+    {
+        public static StonesAndPounds ToStonesAndPounds(this decimal weightInPounds)
+        {
+            int stones = Convert.ToInt32(Math.Truncate(weightInPounds / Constants.App.PoundsInAStone));
+            decimal pounds = weightInPounds % Constants.App.PoundsInAStone;
+
+            return new StonesAndPounds(stones, pounds);
+        }
+
+        public static decimal ToStonesDecimal(this decimal weightInPounds)
+        {
+            return weightInPounds / Constants.App.PoundsInAStone;
+        }
+
+        public static decimal ToPoundsDecimal(this StonesAndPounds stonesPounds)
+        {
+            return (stonesPounds.Stones * Constants.App.PoundsInAStone) + stonesPounds.Pounds;
+        }
+
+        // Turns something like "1.1" into "1st 1.1lbs"
+        public static string ToLongStonesPoundsString(this decimal stonesDecimal)
+        {
+            var stonesAndPounds = stonesDecimal.ToStonesAndPounds();
+            return string.Format(Constants.Strings.Common_Stones_WeightFormat, stonesAndPounds.Stones, stonesAndPounds.Pounds);
+        }
+
+        public static string PoundsToShortStonesDecimalString(this decimal weightInPounds)
+        {
+            var weightInStones = weightInPounds.ToStonesDecimal();
+            return string.Format(Constants.Strings.Common_Stones_ShortWeightFormat, weightInStones);
+        }
+    }
+}

--- a/LineDietXF/LineDietXF/Helpers/WeightLogicHelpers.cs
+++ b/LineDietXF/LineDietXF/Helpers/WeightLogicHelpers.cs
@@ -300,5 +300,10 @@ namespace LineDietXF.Helpers
         {
             return weightInPounds / Constants.App.PoundsInAStone;
         }
+
+        public static decimal ConvertStonesToDecimal(Tuple<int, decimal> stonePounds)
+        {
+            return (stonePounds.Item1 * Constants.App.PoundsInAStone) + stonePounds.Item2;
+        }
     }
 }

--- a/LineDietXF/LineDietXF/Helpers/WeightLogicHelpers.cs
+++ b/LineDietXF/LineDietXF/Helpers/WeightLogicHelpers.cs
@@ -1,4 +1,5 @@
 ﻿using LineDietXF.Enumerations;
+using LineDietXF.Extensions;
 using LineDietXF.Types;
 using System;
 using System.Collections.Generic;
@@ -253,10 +254,10 @@ namespace LineDietXF.Helpers
             }
             else // special formatting for stones/pounds
             {
-                Tuple<int, decimal> lostInStones = ConvertPoundsToStonesAndPounds(Math.Abs(amountLost));
-                Tuple<int, decimal> remainingInStones = ConvertPoundsToStonesAndPounds(amountRemaining);
-                return string.Format(Constants.Strings.DailyInfoPage_Stones_ProgressSummary, gainedLost, lostInStones.Item1, lostInStones.Item2, daysSinceStart,
-                    daysToGo, remainingInStones.Item1, remainingInStones.Item2, endingText);
+                var lostInStones = Math.Abs(amountLost).ToStonesAndPounds();
+                var remainingInStones = amountRemaining.ToStonesAndPounds();
+                return string.Format(Constants.Strings.DailyInfoPage_Stones_ProgressSummary, gainedLost, lostInStones.Stones, lostInStones.Pounds, daysSinceStart,
+                    daysToGo, remainingInStones.Stones, remainingInStones.Pounds, endingText);
             }
         }
 
@@ -285,25 +286,6 @@ namespace LineDietXF.Helpers
 #endif
                 return weightValue;
             }
-        }
-
-        // 14 pounds per stone
-        public static Tuple<int, decimal> ConvertPoundsToStonesAndPounds(decimal weightInPounds)
-        {
-            int stones = Convert.ToInt32(Math.Truncate(weightInPounds / Constants.App.PoundsInAStone));
-            decimal pounds = weightInPounds % Constants.App.PoundsInAStone;
-
-            return new Tuple<int, decimal>(stones, pounds);
-        }
-
-        public static decimal ConvertPoundsToStonesOnly(decimal weightInPounds)
-        {
-            return weightInPounds / Constants.App.PoundsInAStone;
-        }
-
-        public static decimal ConvertStonesToDecimal(Tuple<int, decimal> stonePounds)
-        {
-            return (stonePounds.Item1 * Constants.App.PoundsInAStone) + stonePounds.Item2;
         }
     }
 }

--- a/LineDietXF/LineDietXF/Helpers/WeightLogicHelpers.cs
+++ b/LineDietXF/LineDietXF/Helpers/WeightLogicHelpers.cs
@@ -295,5 +295,10 @@ namespace LineDietXF.Helpers
 
             return new Tuple<int, decimal>(stones, pounds);
         }
+
+        public static decimal ConvertPoundsToStonesOnly(decimal weightInPounds)
+        {
+            return weightInPounds / Constants.App.PoundsInAStone;
+        }
     }
 }

--- a/LineDietXF/LineDietXF/Helpers/WeightLogicHelpers.cs
+++ b/LineDietXF/LineDietXF/Helpers/WeightLogicHelpers.cs
@@ -19,6 +19,8 @@ namespace LineDietXF.Helpers
                     return Constants.Strings.Settings_ImperialPound;
                 case WeightUnitEnum.Kilograms:
                     return Constants.Strings.Settings_Kilograms;
+                case WeightUnitEnum.StonesAndPounds:
+                    return Constants.Strings.Settings_StonesAndPounds;
                 default:
 #if DEBUG
                     Debugger.Break();
@@ -35,6 +37,9 @@ namespace LineDietXF.Helpers
                     return Constants.Strings.Common_WeightUnit_ImperialPounds;
                 case WeightUnitEnum.Kilograms:
                     return Constants.Strings.Common_WeightUnit_Kilograms;
+                case WeightUnitEnum.StonesAndPounds:
+                    // NOTE:: this method is not used for the summary info as stones are displayed as "X stones, X.X pounds", unlike other unit types
+                    return Constants.Strings.Common_WeightUnit_Stones; 
                 default:
 #if DEBUG
                     Debugger.Break();
@@ -61,14 +66,17 @@ namespace LineDietXF.Helpers
             {
                 if (goal != null)
                 {
-                    var goalPadding = (weightUnit == WeightUnitEnum.ImperialPounds ? Constants.App.Graph_GoalOnly_Pounds_Padding : Constants.App.Graph_GoalOnly_Kilograms_Padding);
+                    var goalPadding = (weightUnit == WeightUnitEnum.ImperialPounds || weightUnit == WeightUnitEnum.StonesAndPounds ? 
+                        Constants.App.Graph_GoalOnly_Pounds_Padding : Constants.App.Graph_GoalOnly_Kilograms_Padding);
                     // there should normally be at least one weight if a goal is set, there is nothing really to graph but the goal line itself
                     return new Tuple<decimal, decimal>(goal.GoalWeight - goalPadding, goal.GoalWeight + goalPadding);
                 }
 
                 // no goal set and no saved weights, so just graph a default range
-                var rangeDefaultMin = (weightUnit == WeightUnitEnum.ImperialPounds ? Constants.App.Graph_WeightRange_Pounds_DefaultMin : Constants.App.Graph_WeightRange_Kilograms_DefaultMin);
-                var rangeDefaultMax = (weightUnit == WeightUnitEnum.ImperialPounds ? Constants.App.Graph_WeightRange_Pounds_DefaultMax : Constants.App.Graph_WeightRange_Kilograms_DefaultMax);
+                var rangeDefaultMin = (weightUnit == WeightUnitEnum.ImperialPounds || weightUnit == WeightUnitEnum.StonesAndPounds ? 
+                    Constants.App.Graph_WeightRange_Pounds_DefaultMin : Constants.App.Graph_WeightRange_Kilograms_DefaultMin);
+                var rangeDefaultMax = (weightUnit == WeightUnitEnum.ImperialPounds || weightUnit == WeightUnitEnum.StonesAndPounds ? 
+                    Constants.App.Graph_WeightRange_Pounds_DefaultMax : Constants.App.Graph_WeightRange_Kilograms_DefaultMax);
                 return new Tuple<decimal, decimal>(rangeDefaultMin, rangeDefaultMax);
             }
 
@@ -236,9 +244,20 @@ namespace LineDietXF.Helpers
             // NOTE: we don't want to say "-1.2 gained" so we always make sure what we display is positive
             string gainedLost = (amountLost < 0) ? Constants.Strings.DailyInfoPage_Summary_Gained : Constants.Strings.DailyInfoPage_Summary_Lost;
             string endingText = (todaysEntry.Weight <= todaysGoalWeight) ? Constants.Strings.DailyInfoPage_SummaryEnding_OnTrack : Constants.Strings.DailyInfoPage_SummaryEnding_OffTrack;
-            string weightUnits = goal.WeightUnit.ToSentenceUsageName();
-            return string.Format(Constants.Strings.DailyInfoPage_ProgressSummary, gainedLost, Math.Abs(amountLost), weightUnits, daysSinceStart,
-                daysToGo, amountRemaining, endingText);
+
+            if (goal.WeightUnit != WeightUnitEnum.StonesAndPounds)
+            {
+                string weightUnits = goal.WeightUnit.ToSentenceUsageName();
+                return string.Format(Constants.Strings.DailyInfoPage_ProgressSummary, gainedLost, Math.Abs(amountLost), weightUnits, daysSinceStart,
+                    daysToGo, amountRemaining, endingText);
+            }
+            else // special formatting for stones/pounds
+            {
+                Tuple<int, decimal> lostInStones = ConvertPoundsToStonesAndPounds(Math.Abs(amountLost));
+                Tuple<int, decimal> remainingInStones = ConvertPoundsToStonesAndPounds(amountRemaining);
+                return string.Format(Constants.Strings.DailyInfoPage_Stones_ProgressSummary, gainedLost, lostInStones.Item1, lostInStones.Item2, daysSinceStart,
+                    daysToGo, remainingInStones.Item1, remainingInStones.Item2, endingText);
+            }
         }
 
         public static decimal ConvertWeightUnits(decimal weightValue, WeightUnitEnum origUnits, WeightUnitEnum newUnits)
@@ -246,11 +265,16 @@ namespace LineDietXF.Helpers
             if (origUnits == newUnits)
                 return weightValue;
 
-            if (origUnits == WeightUnitEnum.ImperialPounds && newUnits == WeightUnitEnum.Kilograms)
+            // we treat pounds and stones/pounds the same (just changes in how shown on graph, text, etc. - stored the same)
+            if (origUnits == WeightUnitEnum.ImperialPounds && newUnits == WeightUnitEnum.StonesAndPounds ||
+                origUnits == WeightUnitEnum.StonesAndPounds && newUnits == WeightUnitEnum.ImperialPounds)
+                return weightValue;
+
+            if ((origUnits == WeightUnitEnum.ImperialPounds || origUnits == WeightUnitEnum.StonesAndPounds) && newUnits == WeightUnitEnum.Kilograms)
             {
                 return weightValue * Constants.App.PoundsToKilograms;
             }
-            else if (origUnits == WeightUnitEnum.Kilograms && newUnits == WeightUnitEnum.ImperialPounds)
+            else if (origUnits == WeightUnitEnum.Kilograms && (newUnits == WeightUnitEnum.ImperialPounds || newUnits == WeightUnitEnum.StonesAndPounds))
             {
                 return weightValue * Constants.App.KilogramsToPounds;
             }
@@ -261,6 +285,15 @@ namespace LineDietXF.Helpers
 #endif
                 return weightValue;
             }
+        }
+
+        // 14 pounds per stone
+        public static Tuple<int, decimal> ConvertPoundsToStonesAndPounds(decimal weightInPounds)
+        {
+            int stones = Convert.ToInt32(Math.Truncate(weightInPounds / Constants.App.PoundsInAStone));
+            decimal pounds = weightInPounds % Constants.App.PoundsInAStone;
+
+            return new Tuple<int, decimal>(stones, pounds);
         }
     }
 }

--- a/LineDietXF/LineDietXF/LineDietXF.csproj
+++ b/LineDietXF/LineDietXF/LineDietXF.csproj
@@ -44,6 +44,7 @@
     <Compile Include="Constants.UI.cs" />
     <Compile Include="Converters\WeightListingFontSizeConverter.cs" />
     <Compile Include="Enumerations\WeightUnitEnum.cs" />
+    <Compile Include="Extensions\StonesAndPoundsExtensions.cs" />
     <Compile Include="Types\GettingStartedCarouselItem.cs" />
     <Compile Include="Controls\CarouselLayout.cs" />
     <Compile Include="Controls\LoadingIndicator.xaml.cs">
@@ -67,6 +68,7 @@
     <Compile Include="Services\WindowColorService.cs" />
     <Compile Include="Types\InfoForToday.cs" />
     <Compile Include="Types\ResultWithErrorText.cs" />
+    <Compile Include="Types\StonesAndPounds.cs" />
     <Compile Include="Types\WeightLossGoal.cs" />
     <Compile Include="ViewModels\AboutPageViewModel.cs" />
     <Compile Include="ViewModels\BaseViewModel.cs" />

--- a/LineDietXF/LineDietXF/LineDietXF.csproj
+++ b/LineDietXF/LineDietXF/LineDietXF.csproj
@@ -42,6 +42,7 @@
     <Compile Include="Constants.Analytics.cs" />
     <Compile Include="Constants.Strings.cs" />
     <Compile Include="Constants.UI.cs" />
+    <Compile Include="Converters\WeightListingFontSizeConverter.cs" />
     <Compile Include="Enumerations\WeightUnitEnum.cs" />
     <Compile Include="Types\GettingStartedCarouselItem.cs" />
     <Compile Include="Controls\CarouselLayout.cs" />

--- a/LineDietXF/LineDietXF/Types/StonesAndPounds.cs
+++ b/LineDietXF/LineDietXF/Types/StonesAndPounds.cs
@@ -1,0 +1,14 @@
+﻿namespace LineDietXF.Types
+{
+    public class StonesAndPounds
+    {
+        public int Stones { get; set; }
+        public decimal Pounds { get; set; }
+
+        public StonesAndPounds(int stones, decimal pounds)
+        {
+            Stones = stones;
+            Pounds = pounds;
+        }
+    }
+}

--- a/LineDietXF/LineDietXF/Types/WeightEntry.cs
+++ b/LineDietXF/LineDietXF/Types/WeightEntry.cs
@@ -1,4 +1,5 @@
 ﻿using LineDietXF.Enumerations;
+using LineDietXF.Extensions;
 using LineDietXF.Helpers;
 using SQLite;
 using System;
@@ -49,14 +50,9 @@ namespace LineDietXF.Types
             }
 
             if (WeightUnit == WeightUnitEnum.StonesAndPounds)
-            {
-                var stonesAndPounds = WeightLogicHelpers.ConvertPoundsToStonesAndPounds(Weight);
-                return string.Format(Constants.Strings.Common_Stones_WeightFormat, stonesAndPounds.Item1, stonesAndPounds.Item2);
-            }
+                return Weight.ToLongStonesPoundsString();
             else
-            {
                 return string.Format(Constants.Strings.Common_WeightFormat, Weight);
-            }
         }
     }
 }

--- a/LineDietXF/LineDietXF/Types/WeightEntry.cs
+++ b/LineDietXF/LineDietXF/Types/WeightEntry.cs
@@ -1,4 +1,5 @@
 ﻿using LineDietXF.Enumerations;
+using LineDietXF.Helpers;
 using SQLite;
 using System;
 using System.Diagnostics;
@@ -47,7 +48,15 @@ namespace LineDietXF.Types
                 return "<error>";
             }
 
-            return string.Format(Constants.Strings.Common_WeightFormat, Weight);
+            if (WeightUnit == WeightUnitEnum.StonesAndPounds)
+            {
+                var stonesAndPounds = WeightLogicHelpers.ConvertPoundsToStonesAndPounds(Weight);
+                return string.Format(Constants.Strings.Common_Stones_WeightFormat, stonesAndPounds.Item1, stonesAndPounds.Item2);
+            }
+            else
+            {
+                return string.Format(Constants.Strings.Common_WeightFormat, Weight);
+            }
         }
     }
 }

--- a/LineDietXF/LineDietXF/ViewModels/DailyInfoPageViewModel.cs
+++ b/LineDietXF/LineDietXF/ViewModels/DailyInfoPageViewModel.cs
@@ -55,6 +55,13 @@ namespace LineDietXF.ViewModels
             set { SetProperty(ref _isSetGoalButtonVisible, value); }
         }
 
+        int _mainLabelFontSize;
+        public int MainLabelFontSize
+        {
+            get { return _mainLabelFontSize; }
+            set { SetProperty(ref _mainLabelFontSize, value); }
+        }
+
         #region IActiveAware implementation
 
         public event EventHandler IsActiveChanged;
@@ -182,6 +189,8 @@ namespace LineDietXF.ViewModels
                 IsEnterWeightButtonVisible = infoForToday.IsEnterWeightButtonVisible;
                 IsSetGoalButtonVisible = infoForToday.IsSetGoalButtonVisible;
 
+                MainLabelFontSize = SettingsService.WeightUnit == Enumerations.WeightUnitEnum.StonesAndPounds ?
+                    Constants.UI.DailyInfoFontSize_Stones : Constants.UI.DailyInfoFontSize_Normal;
                 WindowColorService.ChangeAppBaseColor(infoForToday.ColorToShow);
             }
             catch (Exception ex)

--- a/LineDietXF/LineDietXF/ViewModels/DebugPageViewModel.cs
+++ b/LineDietXF/LineDietXF/ViewModels/DebugPageViewModel.cs
@@ -18,6 +18,7 @@ namespace LineDietXF.ViewModels
     {
         // Services        
         IDataService DataService { get; set; }
+        ISettingsService SettingsService { get; set; }
         IEventAggregator EventAggregator { get; set; }
         IWindowColorService WindowColorService { get; set; }
 
@@ -29,11 +30,12 @@ namespace LineDietXF.ViewModels
         public DelegateCommand TestEndingAGoalCommand { get; set; }
         public DelegateCommand TestRealDataSetCommand { get; set; }
 
-        public DebugPageViewModel(INavigationService navigationService, IAnalyticsService analyticsService, IPageDialogService dialogService, IDataService dataService, IEventAggregator eventAggregator, IWindowColorService windowColorService) :
+        public DebugPageViewModel(INavigationService navigationService, IAnalyticsService analyticsService, IPageDialogService dialogService, IDataService dataService, ISettingsService settingsService, IEventAggregator eventAggregator, IWindowColorService windowColorService) :
             base(navigationService, analyticsService, dialogService)
         {
             // Store off injected services
             DataService = dataService;
+            SettingsService = settingsService;
             EventAggregator = eventAggregator;
             WindowColorService = windowColorService;
 
@@ -74,6 +76,14 @@ namespace LineDietXF.ViewModels
 
         async Task<bool> ShowLoseDataWarning()
         {
+            if (SettingsService.WeightUnit != WeightUnitEnum.ImperialPounds)
+            {
+                await DialogService.DisplayAlertAsync("Wrong units", "These methods are only setup for use when using pounds as the units. Change to pounds in Settings before using these methods for creating test data, then change units back.",
+                    Constants.Strings.GENERIC_OK);
+
+                return false;
+            }
+
             return await DialogService.DisplayAlertAsync("Are you sure?", "This will delete all data and set it back up with sample data, are you sure?",
                 Constants.Strings.GENERIC_OK, Constants.Strings.GENERIC_CANCEL);
         }

--- a/LineDietXF/LineDietXF/ViewModels/GraphPageViewModel.cs
+++ b/LineDietXF/LineDietXF/ViewModels/GraphPageViewModel.cs
@@ -279,10 +279,10 @@ namespace LineDietXF.ViewModels
                 });
 
             // YAxis - weights
-            var minRange = SettingsService.WeightUnit == Enumerations.WeightUnitEnum.ImperialPounds ?
+            var minRange = (SettingsService.WeightUnit == Enumerations.WeightUnitEnum.ImperialPounds || SettingsService.WeightUnit == Enumerations.WeightUnitEnum.StonesAndPounds) ?
                         Constants.App.Graph_Pounds_MinWeightRangeVisible :
                         Constants.App.Graph_Kilograms_MinWeightRangeVisible;
-            var maxRange = SettingsService.WeightUnit == Enumerations.WeightUnitEnum.ImperialPounds ?
+            var maxRange = (SettingsService.WeightUnit == Enumerations.WeightUnitEnum.ImperialPounds || SettingsService.WeightUnit == Enumerations.WeightUnitEnum.StonesAndPounds) ?
                         Constants.App.Graph_Pounds_MaxWeightRangeVisible :
                         Constants.App.Graph_Kilograms_MaxWeightRangeVisible;
             plotModel.Axes.Add(

--- a/LineDietXF/LineDietXF/ViewModels/GraphPageViewModel.cs
+++ b/LineDietXF/LineDietXF/ViewModels/GraphPageViewModel.cs
@@ -1,4 +1,5 @@
 ﻿using LineDietXF.Converters;
+using LineDietXF.Enumerations;
 using LineDietXF.Extensions;
 using LineDietXF.Helpers;
 using LineDietXF.Interfaces;
@@ -285,7 +286,8 @@ namespace LineDietXF.ViewModels
             var maxRange = (SettingsService.WeightUnit == Enumerations.WeightUnitEnum.ImperialPounds || SettingsService.WeightUnit == Enumerations.WeightUnitEnum.StonesAndPounds) ?
                         Constants.App.Graph_Pounds_MaxWeightRangeVisible :
                         Constants.App.Graph_Kilograms_MaxWeightRangeVisible;
-            plotModel.Axes.Add(
+
+            var weightAxis =             
                 new LinearAxis
                 {
                     Position = AxisPosition.Left,
@@ -300,12 +302,21 @@ namespace LineDietXF.ViewModels
                     TickStyle = TickStyle.Outside,
                     MajorGridlineStyle = LineStyle.Solid,
                     MinorGridlineStyle = LineStyle.Solid,
-                    MinorStep = 1,
-                    MajorStep = 5,
+                    MinorStep = 1, 
+                    MajorStep = 5, 
                     IsZoomEnabled = true,
                     MinimumRange = minRange, // closest zoom in shows at least 5 pounds
                     MaximumRange = maxRange // furthest zoom out shows at most 100 pounds
-                });
+                };
+
+            // use a special weight axis label formatter for stones/pounds
+            if (SettingsService.WeightUnit == WeightUnitEnum.StonesAndPounds)
+            {
+                weightAxis.LabelFormatter = WeightLabelFormatter;
+                weightAxis.MajorStep = 7;
+            }
+
+            plotModel.Axes.Add(weightAxis);
 
             var series1 = new LineSeries
             {
@@ -399,6 +410,12 @@ namespace LineDietXF.ViewModels
             }
 
             //Debug.WriteLine($"min={dateMin}, max={dateMax}, delta={delta}");
+        }
+
+        string WeightLabelFormatter(double d)
+        {
+            var stones = WeightLogicHelpers.ConvertPoundsToStonesOnly(Convert.ToDecimal(d));
+            return string.Format(Constants.Strings.Common_Stones_ShortWeightFormat, stones);
         }
 
         async void EditEntry(WeightEntry selectedItem)

--- a/LineDietXF/LineDietXF/ViewModels/GraphPageViewModel.cs
+++ b/LineDietXF/LineDietXF/ViewModels/GraphPageViewModel.cs
@@ -414,8 +414,7 @@ namespace LineDietXF.ViewModels
 
         string WeightLabelFormatter(double d)
         {
-            var stones = WeightLogicHelpers.ConvertPoundsToStonesOnly(Convert.ToDecimal(d));
-            return string.Format(Constants.Strings.Common_Stones_ShortWeightFormat, stones);
+            return Convert.ToDecimal(d).PoundsToShortStonesDecimalString();
         }
 
         async void EditEntry(WeightEntry selectedItem)

--- a/LineDietXF/LineDietXF/ViewModels/SetGoalPageViewModel.cs
+++ b/LineDietXF/LineDietXF/ViewModels/SetGoalPageViewModel.cs
@@ -112,6 +112,22 @@ namespace LineDietXF.ViewModels
             set { SetProperty(ref _showPoundsEntryFields, value); }
         }
 
+        public string StartWeightLabel
+        {
+            get
+            {
+                return string.Format(Constants.Strings.SetGoalPage_StartWeightLabel, SettingsService.WeightUnit.ToSentenceUsageName());
+            }
+        }
+
+        public string GoalWeightLabel
+        {
+            get
+            {
+                return string.Format(Constants.Strings.SetGoalPage_GoalWeightLabel, SettingsService.WeightUnit.ToSentenceUsageName());
+            }
+        }
+
         // Services
         IDataService DataService { get; set; }
         ISettingsService SettingsService { get; set; }
@@ -272,6 +288,10 @@ namespace LineDietXF.ViewModels
             if (startWeightStones < 0 || startWeightPounds < 0)
                 return null;
 
+            // don't allow pounds to be 14 or more (would be another stone)
+            if (startWeightPounds >= Constants.App.PoundsInAStone)
+                return null;
+
             return new StonesAndPounds(startWeightStones, startWeightPounds);
         }
 
@@ -291,6 +311,10 @@ namespace LineDietXF.ViewModels
 
             // don't allow negative values
             if (goalWeightStones < 0 || goalWeightPounds < 0)
+                return null;
+
+            // don't allow pounds to be 14 or more (would be another stone)
+            if (goalWeightPounds >= Constants.App.PoundsInAStone)
                 return null;
 
             return new StonesAndPounds(goalWeightStones, goalWeightPounds);

--- a/LineDietXF/LineDietXF/ViewModels/WeightEntryPageViewModel.cs
+++ b/LineDietXF/LineDietXF/ViewModels/WeightEntryPageViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using LineDietXF.Enumerations;
 using LineDietXF.Extensions;
+using LineDietXF.Helpers;
 using LineDietXF.Interfaces;
 using LineDietXF.Types;
 using Prism.Commands;
@@ -72,6 +73,14 @@ namespace LineDietXF.ViewModels
         {
             get { return _showPoundsEntryFields; }
             set { SetProperty(ref _showPoundsEntryFields, value); }
+        }
+
+        public string WeightLabel
+        {
+            get
+            {
+                return string.Format(Constants.Strings.WeightEntrylPage_WeightLabel, SettingsService.WeightUnit.ToSentenceUsageName());
+            }
         }
 
         // Bindable Commands
@@ -156,6 +165,10 @@ namespace LineDietXF.ViewModels
 
             // don't allow negative values
             if (weightStones < 0 || weightPounds < 0)
+                return null;
+
+            // don't allow pounds to be 14 or more (would be another stone)
+            if (weightPounds >= Constants.App.PoundsInAStone)
                 return null;
 
             return new StonesAndPounds(weightStones, weightPounds);

--- a/LineDietXF/LineDietXF/Views/DailyInfoPage.xaml
+++ b/LineDietXF/LineDietXF/Views/DailyInfoPage.xaml
@@ -24,9 +24,10 @@
                      VerticalOptions="Center"
                      Padding="20,10"
                      Spacing="10">
+            <!-- NOTE:: the font size is dynamicly bound to MainLabelFontSize as weight in stones is much longer (ex: "15st 9.4lb" instead of "219.4" -->
             <Label HorizontalOptions="Center" 
 				   Style="{StaticResource ThinLabelStyle}"
- 				   FontSize="72"
+ 				   FontSize="{Binding MainLabelFontSize}"
 				   Text="{Binding TodaysWeight}">
                 <Label.GestureRecognizers>
                     <TapGestureRecognizer Command="{Binding AddEntryCommand}" NumberOfTapsRequired="1" />

--- a/LineDietXF/LineDietXF/Views/GraphPage.xaml
+++ b/LineDietXF/LineDietXF/Views/GraphPage.xaml
@@ -52,18 +52,18 @@
                             </ViewCell.ContextActions>
                             <Grid Padding="10,4">
                                 <Grid.ColumnDefinitions>
-                                    <ColumnDefinition Width="3*" />
                                     <ColumnDefinition Width="*" />
-                                    <ColumnDefinition Width="40" />
+                                    <ColumnDefinition Width="Auto" />
+                                    <ColumnDefinition Width="32" />
                                 </Grid.ColumnDefinitions>
-                                <Label FontSize="24"
+                                <Label FontSize="{Binding ., Converter={StaticResource WeightListingFontSizeCvt}}"
 								       HorizontalOptions="Start"
                                        VerticalOptions="Center"
 								       Style="{StaticResource ThinLabelStyle}"
 								       Text="{Binding Date, Converter={StaticResource DateCvt}}"/>
                                 <Label Grid.Column="1" 
 								       Style="{StaticResource ThinLabelStyle}"
-								       FontSize="24"
+								       FontSize="{Binding ., Converter={StaticResource WeightListingFontSizeCvt}}"
 			   					       HorizontalOptions="End"
                                        VerticalOptions="Center"
 								       Text="{Binding ., Converter={StaticResource WeightCvt}}"/>

--- a/LineDietXF/LineDietXF/Views/SetGoalPage.xaml
+++ b/LineDietXF/LineDietXF/Views/SetGoalPage.xaml
@@ -82,12 +82,15 @@
                 </Grid>                
 
                 <!-- bottom buttons -->
-                <Button Margin="0,20,0,0" Text="Set Goal"
-                        Style="{StaticResource BoxButtonStyle}"
-                        Command="{Binding SaveCommand}"/>
-                <Button Text="Cancel"
-                        Style="{StaticResource BoxButtonStyle}"
-                        Command="{Binding CloseCommand}"/>
+                <StackLayout Style="{StaticResource ButtonWrappingPanel}">
+                    <Button Text="Set Goal"
+                            Style="{StaticResource BoxButtonStyle}"
+                            Command="{Binding SaveCommand}"/>
+                    <Button Text="Cancel"
+                            Style="{StaticResource BoxButtonStyle}"
+                            Command="{Binding CloseCommand}"/>
+                </StackLayout>
+                
             </StackLayout>
         </ScrollView>
 

--- a/LineDietXF/LineDietXF/Views/SetGoalPage.xaml
+++ b/LineDietXF/LineDietXF/Views/SetGoalPage.xaml
@@ -32,7 +32,7 @@
                             Date="{Binding StartDate}"/>
 
                 <!-- start weight section (shows different fields for stones unit type) -->
-                <Label Text="Start Weight" 
+                <Label Text="{Binding StartWeightLabel}" 
                        Style="{StaticResource FieldLabelStyle}"/>
                 <Grid IsVisible="{Binding ShowStonesEntryFields, Converter={StaticResource InverseBoolConverter}}">
                     <Entry Style="{StaticResource WeightEntryStyle}"
@@ -60,7 +60,7 @@
                             Date="{Binding GoalDate}"/>
 
                 <!-- goal weight section (shows different fields for stones unit type) -->
-                <Label Text="Goal Weight"
+                <Label Text="{Binding GoalWeightLabel}"
                        Style="{StaticResource FieldLabelStyle}"/>
                 <Grid IsVisible="{Binding ShowStonesEntryFields, Converter={StaticResource InverseBoolConverter}}">
                     <Entry Style="{StaticResource WeightEntryStyle}"

--- a/LineDietXF/LineDietXF/Views/SetGoalPage.xaml
+++ b/LineDietXF/LineDietXF/Views/SetGoalPage.xaml
@@ -24,31 +24,65 @@
                 <Label Style="{StaticResource SubtitleLabelStyle}"
                        Text="Pick your goal weight, and the date you'd like to achieve it by. Make sure your goal is reasonable." />
 
+                <!-- start date -->
                 <Label Text="Start Date" 
                        Margin="0, 20, 0, 0"
                        Style="{StaticResource FieldLabelStyle}"/>
                 <DatePicker Style="{StaticResource DateEntryStyle}"
                             Date="{Binding StartDate}"/>
 
+                <!-- start weight section (shows different fields for stones unit type) -->
                 <Label Text="Start Weight" 
                        Style="{StaticResource FieldLabelStyle}"/>
-                <Entry Style="{StaticResource WeightEntryStyle}"
-                       Text="{Binding StartWeight}"
-                       Placeholder="Enter starting weight (ex: 180.0)"/>
+                <Grid IsVisible="{Binding ShowStonesEntryFields, Converter={StaticResource InverseBoolConverter}}">
+                    <Entry Style="{StaticResource WeightEntryStyle}"
+                           Text="{Binding StartWeight}"
+                           Placeholder="Enter starting weight (ex: 180.0)"/>
+                </Grid>
+                <Grid IsVisible="{Binding ShowStonesEntryFields}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Entry Style="{StaticResource WeightEntryStyle}"
+                           Text="{Binding StartWeightStones}"
+                           Placeholder="Stones (ex: 10)"/>
+                    <Entry Grid.Column="1" 
+                           Style="{StaticResource WeightEntryStyle}"
+                           Text="{Binding StartWeightStonePounds}"
+                           Placeholder="Pounds (ex: 12.2)"/>
+                </Grid>
 
+                <!-- goal date -->
                 <Label Text="Goal Date"
                        Style="{StaticResource FieldLabelStyle}"/>
                 <DatePicker Style="{StaticResource DateEntryStyle}"
                             Date="{Binding GoalDate}"/>
 
+                <!-- goal weight section (shows different fields for stones unit type) -->
                 <Label Text="Goal Weight"
                        Style="{StaticResource FieldLabelStyle}"/>
-                <Entry Margin="0,0,0,20" 
-                       Style="{StaticResource WeightEntryStyle}"
-                       Text="{Binding GoalWeight}"
-                       Placeholder="Enter goal weight (ex: 160.0)"/>
+                <Grid IsVisible="{Binding ShowStonesEntryFields, Converter={StaticResource InverseBoolConverter}}">
+                    <Entry Style="{StaticResource WeightEntryStyle}"
+                           Text="{Binding GoalWeight}"
+                           Placeholder="Enter goal weight (ex: 160.0)"/>
+                </Grid>
+                <Grid IsVisible="{Binding ShowStonesEntryFields}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Entry Style="{StaticResource WeightEntryStyle}"
+                           Text="{Binding GoalWeightStones}"
+                           Placeholder="Stones (ex: 10)"/>
+                    <Entry Grid.Column="1" 
+                           Style="{StaticResource WeightEntryStyle}"
+                           Text="{Binding GoalWeightStonePounds}"
+                           Placeholder="Pounds (ex: 12.2)"/>
+                </Grid>                
 
-                <Button Text="Set Goal"
+                <!-- bottom buttons -->
+                <Button Margin="0,20,0,0" Text="Set Goal"
                         Style="{StaticResource BoxButtonStyle}"
                         Command="{Binding SaveCommand}"/>
                 <Button Text="Cancel"

--- a/LineDietXF/LineDietXF/Views/WeightEntryPage.xaml
+++ b/LineDietXF/LineDietXF/Views/WeightEntryPage.xaml
@@ -28,12 +28,12 @@
 
                 <Label Text="Weight" 
                        Style="{StaticResource FieldLabelStyle}"/>
-                <Entry Margin="0,0,0,20" 
-                       Style="{StaticResource WeightEntryStyle}"
+                <Entry Style="{StaticResource WeightEntryStyle}"
                        Text="{Binding Weight}"
                        Placeholder="Enter weight (ex: 123.4)"/>
 
-                <Button Text="Save"
+                <Button Margin="0,20,0,0"
+                        Text="Save"
                         Style="{StaticResource BoxButtonStyle}"
                         Command="{Binding SaveCommand}"/>
                 <Button Text="Cancel"

--- a/LineDietXF/LineDietXF/Views/WeightEntryPage.xaml
+++ b/LineDietXF/LineDietXF/Views/WeightEntryPage.xaml
@@ -27,7 +27,7 @@
                             Style="{StaticResource DateEntryStyle}"/>
 
                 <!-- weight section (shows different fields for stones unit type) -->
-                <Label Text="Weight" 
+                <Label Text="{Binding WeightLabel}" 
                        Style="{StaticResource FieldLabelStyle}"/>
                 <Grid IsVisible="{Binding ShowStonesEntryFields, Converter={StaticResource InverseBoolConverter}}">
                     <Entry Style="{StaticResource WeightEntryStyle}"

--- a/LineDietXF/LineDietXF/Views/WeightEntryPage.xaml
+++ b/LineDietXF/LineDietXF/Views/WeightEntryPage.xaml
@@ -26,11 +26,27 @@
                 <DatePicker Date="{Binding Date}"
                             Style="{StaticResource DateEntryStyle}"/>
 
+                <!-- weight section (shows different fields for stones unit type) -->
                 <Label Text="Weight" 
                        Style="{StaticResource FieldLabelStyle}"/>
-                <Entry Style="{StaticResource WeightEntryStyle}"
-                       Text="{Binding Weight}"
-                       Placeholder="Enter weight (ex: 123.4)"/>
+                <Grid IsVisible="{Binding ShowStonesEntryFields, Converter={StaticResource InverseBoolConverter}}">
+                    <Entry Style="{StaticResource WeightEntryStyle}"
+                           Text="{Binding Weight}"
+                           Placeholder="Enter weight (ex: 123.4)"/>
+                </Grid>
+                <Grid IsVisible="{Binding ShowStonesEntryFields}">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*" />
+                        <ColumnDefinition Width="*" />
+                    </Grid.ColumnDefinitions>
+                    <Entry Style="{StaticResource WeightEntryStyle}"
+                           Text="{Binding WeightStones}"
+                           Placeholder="Stones (ex: 10)"/>
+                    <Entry Grid.Column="1" 
+                           Style="{StaticResource WeightEntryStyle}"
+                           Text="{Binding WeightStonePounds}"
+                           Placeholder="Pounds (ex: 12.2)"/>
+                </Grid>
 
                 <Button Margin="0,20,0,0"
                         Text="Save"

--- a/LineDietXF/LineDietXF/Views/WeightEntryPage.xaml
+++ b/LineDietXF/LineDietXF/Views/WeightEntryPage.xaml
@@ -48,13 +48,16 @@
                            Placeholder="Pounds (ex: 12.2)"/>
                 </Grid>
 
-                <Button Margin="0,20,0,0"
-                        Text="Save"
-                        Style="{StaticResource BoxButtonStyle}"
-                        Command="{Binding SaveCommand}"/>
-                <Button Text="Cancel"
-                        Style="{StaticResource BoxButtonStyle}"
-                        Command="{Binding CloseCommand}"/>
+                <!-- bottom buttons -->
+                <StackLayout Style="{StaticResource ButtonWrappingPanel}">
+                    <Button Text="Save"
+                            Style="{StaticResource BoxButtonStyle}"
+                            Command="{Binding SaveCommand}"/>
+                    <Button Text="Cancel"
+                            Style="{StaticResource BoxButtonStyle}"
+                            Command="{Binding CloseCommand}"/>
+                </StackLayout>
+                
             </StackLayout>
         </ScrollView>
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Line Diet is a mobile app for tracking and graphing your diet based off of a sim
 * Loading/Saving of app settings *(via Settings Plugin for Xamarin and Windows)*
 * Sharing of app via various social networks *(via Share Plugin for Xamarin and Windows)*
 * Data bound ListViews with context menu for deletion
+* Support for weight units in pounds, kilograms, and stones
 
 ## Potential Future Improvements
 * Support more platforms (ex: Windows Phone, Apple Watch, Windows 10, Android Wear)


### PR DESCRIPTION
Added support for measurement unit of Stones. Stones are stored the same as pounds, however graphing, data entry, and display converts the pounds to Stones and Pounds. For example, 237.4 pounds becomes 16 stones, 13.4 pounds.